### PR TITLE
resolve #19: Persist precondition test events from command line

### DIFF
--- a/rooset-application-toolkit/ratk-declarations-utils/index.js
+++ b/rooset-application-toolkit/ratk-declarations-utils/index.js
@@ -8,4 +8,5 @@ module.exports = {
   findCommandSchemaByType: require('./src/findCommandSchemaByType'),
   findHttpCommandRequestByUri: require('./src/findHttpCommandRequestByUri'),
   matchUri: require('./src/matchUri'),
+  getTestPrecondition: require('./src/getTestPrecondition'),
 };

--- a/rooset-application-toolkit/ratk-declarations-utils/src/getTestPrecondition.js
+++ b/rooset-application-toolkit/ratk-declarations-utils/src/getTestPrecondition.js
@@ -18,5 +18,5 @@ module.exports = (testKey, scenarioKey) => {
       Could not find scenario with key ${scenarioKey} in test with key ${testKey}`);
 
   const events = scenario.given.precondition;
-  console.log(JSON.stringify(events, null, 2));
+  return events;
 };

--- a/rooset-application-toolkit/ratk-declarations-utils/src/getTestPrecondition.js
+++ b/rooset-application-toolkit/ratk-declarations-utils/src/getTestPrecondition.js
@@ -1,0 +1,22 @@
+const { find } = require('lodash');
+const getConfigFromEnv = require('./getConfigFromEnv');
+const getTests = require('./getTests');
+
+const config = getConfigFromEnv({
+  testSrcPath: 'RATK_GEN_TEST_DECL_DIR',
+});
+
+
+module.exports = (testKey, scenarioKey) => {
+  const testSpecs = getTests(config.testSrcPath, 'ALL', false);
+  const testSpec = find(testSpecs, (spec) => spec.key === testKey);
+  if (!testSpec) throw new Error(`
+      Could not find spec with key ${testKey}`);
+  const scenario = find(testSpec.scenarios,
+      (scenario) => scenario.given.key === scenarioKey);
+  if (!scenario) throw new Error(`
+      Could not find scenario with key ${scenarioKey} in test with key ${testKey}`);
+
+  const events = scenario.given.precondition;
+  console.log(JSON.stringify(events, null, 2));
+};

--- a/rooset-application-toolkit/ratk-declarations-utils/src/getTests.js
+++ b/rooset-application-toolkit/ratk-declarations-utils/src/getTests.js
@@ -22,7 +22,7 @@ const testTypeEnumValues = [
 
 
 
-module.exports = (_srcPath, testType) => {
+module.exports = (_srcPath, testType, doStripMetadata = true) => {
   const allTestSpecs = {};
   if (testTypeEnumValues.indexOf(testType) === -1) {
     throw new Error(`testType must be one of ${testTypeEnumValues}, it is ${testType}`);
@@ -44,7 +44,7 @@ module.exports = (_srcPath, testType) => {
   return chain(jsonTests.concat(yamlTests))
       .map((d) => addToAllTestSpecs(d))
       .map((d) => injectPreconditions(d))
-      .map((d) => stripMetadata(d))
+      .map((d) => doStripMetadata ? stripMetadata(d) : d)
       .filter((d) => (testType === 'ALL' || d.type === testType))
       .value();
 

--- a/rooset-application-toolkit/tools/package.json
+++ b/rooset-application-toolkit/tools/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "rooset-application-toolkit-tools",
+  "version": "0.1.0",
+  "description": "General tools for ratk",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ddouglascarr/rooset.git"
+  },
+  "author": "Daniel Carr <d.douglas.carr@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ddouglascarr/rooset/issues"
+  },
+  "homepage": "https://github.com/ddouglascarr/rooset#readme",
+  "dependencies": {
+    "lodash": "^4.17.4",
+    "uuid4": "^1.0.0"
+  }
+}

--- a/rooset-application-toolkit/tools/persist-test-precondition
+++ b/rooset-application-toolkit/tools/persist-test-precondition
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+WORKDIR=`dirname "$(readlink -f "$0")"`
+cd $WORKDIR
+
+export RATK_GEN_TEST_DECL_DIR=${WORKDIR}/../../rooset-declarations/src/tests
+echo $RATK_GEN_TEST_DECL_DIR
+
+curlCommands=$(node -e "require('./src/generateCurlCommands')('$1', '$2')")
+
+eval "${curlCommands}"

--- a/rooset-application-toolkit/tools/persist-test-precondition
+++ b/rooset-application-toolkit/tools/persist-test-precondition
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -o errexit -o nounset -o pipefail
 
+
+########################################
+#
+# Rough tool for persisting a test precondition to
+# EventStore. Don't use this in formal tests. It
+# is for manual testing an experimentation.
+#
+# Usage: ./persist-test-precondition <test-key> <precondition-key>
+# Example: ./persist-test-precondition area-issue-delegation-command area-created
+#
+########################################
+
+
 WORKDIR=`dirname "$(readlink -f "$0")"`
 cd $WORKDIR
 

--- a/rooset-application-toolkit/tools/src/generateCurlCommands.js
+++ b/rooset-application-toolkit/tools/src/generateCurlCommands.js
@@ -1,0 +1,11 @@
+const uuid = require('uuid4');
+const { getTestPrecondition } = require('../../ratk-declarations-utils');
+
+module.exports = (testSpec, preconditionKey) => {
+  const events = getTestPrecondition(testSpec, preconditionKey)
+  const command = events.map((e) => {
+    const streamId = e.payload.id;
+    const eventType = e.type;
+    return `/usr/bin/curl -i "http://localhost:2113/streams/${streamId}" -H "Content-Type:application/json" -H "ES-EventType: ${eventType}" -H "ES-EventId: ${uuid()}" -d '${JSON.stringify(e)}'`
+  }).forEach((e) => console.log(e));
+}


### PR DESCRIPTION

- Adds a bash script which takes preconditions from test scenarios and persists them to EventStore
- Not for formal testing
- Lives in a new tools folder in roost-application-toolkit. 